### PR TITLE
feat: code expression added + security improvements (solution as string and === for compare), version 2.1.0

### DIFF
--- a/lib/captcha.test.ts
+++ b/lib/captcha.test.ts
@@ -28,7 +28,7 @@ describe("verify", () => {
   const signatureKey = "c0ffee";
 
   it("returns false when the captcha has expired", () => {
-    const result = verify(encryptedCaptchaExpression, 7, secret, signatureKey);
+    const result = verify(encryptedCaptchaExpression, '7', secret, signatureKey);
 
     expect(result).toBe(errors.CAPTCHA_EXPIRED);
   });
@@ -44,7 +44,7 @@ describe("verify", () => {
 
     const result = verify(
       captcha.encryptedExpr,
-      solution,
+      solution.toString(),
       "deadbeef",
       signatureKey
     );
@@ -57,7 +57,7 @@ describe("verify", () => {
     config.captchaDuration = 10 * 1000;
 
     const captcha = create(config);
-    const result = verify(captcha.encryptedExpr, 999, "deadbeef", signatureKey);
+    const result = verify(captcha.encryptedExpr, '999', "deadbeef", signatureKey);
 
     expect(result).toBe(errors.INVALID_SOLUTION);
   });

--- a/lib/captcha.ts
+++ b/lib/captcha.ts
@@ -1,4 +1,5 @@
 import { ILambdaCaptchaConfig } from "./config";
+import { LambdaCaptchaCodeExpression } from './expressions/code-expression';
 import { ILambdaCaptchaExpression } from "./expressions/types";
 import { renderText } from "./font";
 import { LambdaCaptchaMathExpression } from "./expressions/math-expression";
@@ -30,6 +31,9 @@ export function create(config: ILambdaCaptchaConfig): ILambdaCaptcha {
   let captcha: ILambdaCaptchaExpression;
 
   switch (config.mode) {
+    case "code":
+      captcha = LambdaCaptchaCodeExpression.generate(config.codeLength);
+      break;
     case "math":
       captcha = LambdaCaptchaMathExpression.generate(2);
       break;
@@ -53,7 +57,7 @@ export function create(config: ILambdaCaptchaConfig): ILambdaCaptcha {
 
 export function verify(
   encryptedExpression: string,
-  solution: any,
+  solution: string,
   key: string,
   signatureKey: string,
 ) {
@@ -81,10 +85,17 @@ export function verify(
   }
 
   switch (captcha.type) {
+    case "code":
+      const codeExpression = LambdaCaptchaCodeExpression.fromJSON(captcha);
+
+      if (codeExpression.solve() === solution) {
+        return true;
+      }
+      return errors.INVALID_SOLUTION;
     case "math":
       const mathExpression = LambdaCaptchaMathExpression.fromJSON(captcha);
 
-      if (mathExpression.solve() == solution) {
+      if (mathExpression.solve().toString() === solution) {
         return true;
       }
       return errors.INVALID_SOLUTION;

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -10,7 +10,7 @@ export type ILambdaCaptchaConfig = {
     /**
      * Mode of the captcha
      */
-    mode: 'math',
+    mode: 'math' | 'code',
     /**
      * Key to encrypt the generated expression
      */
@@ -43,6 +43,10 @@ export type ILambdaCaptchaConfig = {
      * Captcha should be valid until `Date.now() + captchaDuration`
      */
     captchaDuration: number
+    /**
+     * Length of generated code in 'code' mode
+     */
+    codeLength?: number
 }
 
 export class LambdaCaptchaConfigManager {

--- a/lib/expressions/code-expression.test.ts
+++ b/lib/expressions/code-expression.test.ts
@@ -1,0 +1,42 @@
+import { LambdaCaptchaCodeExpression } from "./code-expression";
+
+describe("LambdaCaptchaCodeExpression", () => {
+  it("can be turned into a string", () => {
+    const expression = new LambdaCaptchaCodeExpression('abcde');
+
+    expect(expression.toString()).toBe("abcde");
+  });
+
+  describe("generate", () => {
+    it("returns an LambdaCaptchaCodeExpression", () => {
+      const expression = LambdaCaptchaCodeExpression.generate();
+
+      expect(expression.code).toHaveLength(5);
+    });
+
+    it("returns an LambdaCaptchaCodeExpression with the desired code length", () => {
+      const expression = LambdaCaptchaCodeExpression.generate(4);
+
+      expect(expression.code).toHaveLength(4);
+    });
+  });
+
+  describe("solve", () => {
+    it("solves an expression", () => {
+      const expression = new LambdaCaptchaCodeExpression('abcde');
+
+      expect(expression.solve()).toBe('abcde');
+    });
+  });
+  
+  describe("fromJSON", () => {
+    it("converts JSON back to a code expression", () => {
+      const expression = new LambdaCaptchaCodeExpression('abcde');
+      const rebuilt = LambdaCaptchaCodeExpression.fromJSON(JSON.parse(JSON.stringify(expression.toObject())))
+      
+      expect(rebuilt).toBeInstanceOf(LambdaCaptchaCodeExpression)
+      expect(rebuilt.code).toStrictEqual(expression.code)
+      expect(rebuilt.solve()).toBe(expression.solve())
+    });
+  });
+});

--- a/lib/expressions/code-expression.ts
+++ b/lib/expressions/code-expression.ts
@@ -1,0 +1,32 @@
+import { ILambdaCaptchaExpression } from "./types";
+
+export class LambdaCaptchaCodeExpression implements ILambdaCaptchaExpression {
+  constructor(
+    public readonly code: string,
+  ) {}
+
+  static generate(length = 5): LambdaCaptchaCodeExpression {
+    const code = Math.random().toString(36).substr(2, length);
+
+    return new LambdaCaptchaCodeExpression(code);
+  }
+  
+  static fromJSON(o: any): LambdaCaptchaCodeExpression {
+    return Object.setPrototypeOf(Object.assign({}, o), LambdaCaptchaCodeExpression.prototype)
+  }
+
+  public solve(): string {
+    return this.code;
+  }
+
+  public toString() {
+    return String(this.code);
+  }
+  
+  public toObject() {
+    return {
+      type: 'code',
+      code: this.code
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lambda-captcha",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Changes:
- expression "code" created and added to captcha mode options
- security improvements - solution typed as a string and === used for compare (issue with long floats, e.g. 1 == "1.0000000000000001" returns true)
- version changed to 2.1.0